### PR TITLE
2.0.0: updated neutrino from v5 to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutrino-preset-react-require",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Inject React import when JSX is detected.",
   "keywords": [
     "neutrino",
@@ -12,10 +12,10 @@
   ],
   "dependencies": {
     "babel-plugin-react-require": "^3.0.0",
-    "deepmerge": "^1.3.2"
+    "deepmerge": "^2.0.1"
   },
   "peerDependencies": {
-    "neutrino": "^5.0.0"
+    "neutrino": "^8.0.18"
   },
   "files": ["index.js"],
   "license": "MIT"


### PR DESCRIPTION
Simple deps updates (necessary to update the `node-spa` example in `up-examples`).